### PR TITLE
003 커뮤니티

### DIFF
--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/controller/CommentController.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/controller/CommentController.java
@@ -27,14 +27,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/comments")
+@RequestMapping("/api/posts")
 @RequiredArgsConstructor
 public class CommentController {
 
   private final JwtTokenProvider provider;
   private final CommentService commentService;
 
-  @PostMapping("/{postId}")
+  @PostMapping("/{postId}/comments")
   public ResponseEntity<CommentResponse> createComment(
       @PathVariable Long postId,
       @RequestHeader("Authorization") String authorization,
@@ -42,13 +42,13 @@ public class CommentController {
   ) {
 
     String userId = extractUserId(authorization);
-    Comment comment = commentService.createComment(postId, userId, request);
+    Comment comment = commentService.createComment(postId, userId, request.getContent());
     CommentResponse response = buildResponse(comment);
 
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
-  @GetMapping("/{postId}")
+  @GetMapping("/{postId}/comments")
   public ResponseEntity<PagedResponse<CommentResponse>> getComment(
       @PathVariable Long postId,
       @RequestParam(defaultValue = "0") int page,
@@ -62,28 +62,30 @@ public class CommentController {
     return ResponseEntity.status(HttpStatus.OK).body(responses);
   }
 
-  @PutMapping("/{commentId}")
+  @PutMapping("/{postId}/comments/{commentId}")
   public ResponseEntity<CommentResponse> updateComment(
+      @PathVariable Long postId,
       @PathVariable Long commentId,
       @RequestHeader("Authorization") String authorization,
       @RequestBody UpdateCommentRequest request
   ) {
     String userId = extractUserId(authorization);
-    Comment comment = commentService.updateComment(userId, commentId, request);
+    Comment comment = commentService.updateComment(userId, postId, commentId, request);
     CommentResponse response = buildResponse(comment);
 
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 
 
-  @DeleteMapping("/{commentId}")
+  @DeleteMapping("/{postId}/comments/{commentId}")
   public ResponseEntity<Void> deleteComment(
+      @PathVariable Long postId,
       @PathVariable Long commentId,
       @RequestHeader("Authorization") String authorization
       ) {
       String userId = extractUserId(authorization);
 
-      commentService.deleteComment(userId, commentId);
+      commentService.deleteComment(userId, postId, commentId);
 
       return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/controller/CommentController.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/controller/CommentController.java
@@ -1,0 +1,122 @@
+package com.github.shCHO9801.climbing_record_app.community.comment.controller;
+
+import com.github.shCHO9801.climbing_record_app.climbingsession.dto.PagedResponse;
+import com.github.shCHO9801.climbing_record_app.community.comment.dto.CommentResponse;
+import com.github.shCHO9801.climbing_record_app.community.comment.dto.CreateCommentRequest;
+import com.github.shCHO9801.climbing_record_app.community.comment.dto.UpdateCommentRequest;
+import com.github.shCHO9801.climbing_record_app.community.comment.entity.Comment;
+import com.github.shCHO9801.climbing_record_app.community.comment.service.CommentService;
+import com.github.shCHO9801.climbing_record_app.exception.CustomException;
+import com.github.shCHO9801.climbing_record_app.exception.ErrorCode;
+import com.github.shCHO9801.climbing_record_app.util.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+  private final JwtTokenProvider provider;
+  private final CommentService commentService;
+
+  @PostMapping("/{postId}")
+  public ResponseEntity<CommentResponse> createComment(
+      @PathVariable Long postId,
+      @RequestHeader("Authorization") String authorization,
+      @RequestBody CreateCommentRequest request
+  ) {
+
+    String userId = extractUserId(authorization);
+    Comment comment = commentService.createComment(postId, userId, request);
+    CommentResponse response = buildResponse(comment);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @GetMapping("/{postId}")
+  public ResponseEntity<PagedResponse<CommentResponse>> getComment(
+      @PathVariable Long postId,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size
+  ) {
+    Pageable pageable = PageRequest.of(page, size);
+
+    Page<Comment> comments = commentService.getComments(postId, pageable);
+    PagedResponse<CommentResponse> responses = createPagedResponse(comments);
+
+    return ResponseEntity.status(HttpStatus.OK).body(responses);
+  }
+
+  @PutMapping("/{commentId}")
+  public ResponseEntity<CommentResponse> updateComment(
+      @PathVariable Long commentId,
+      @RequestHeader("Authorization") String authorization,
+      @RequestBody UpdateCommentRequest request
+  ) {
+    String userId = extractUserId(authorization);
+    Comment comment = commentService.updateComment(userId, commentId, request);
+    CommentResponse response = buildResponse(comment);
+
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+
+
+  @DeleteMapping("/{commentId}")
+  public ResponseEntity<Void> deleteComment(
+      @PathVariable Long commentId,
+      @RequestHeader("Authorization") String authorization
+      ) {
+      String userId = extractUserId(authorization);
+
+      commentService.deleteComment(userId, commentId);
+
+      return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  private PagedResponse<CommentResponse> createPagedResponse(Page<Comment> comments) {
+    return PagedResponse.<CommentResponse>builder()
+        .content(comments.getContent().stream()
+            .map(this::buildResponse)
+            .toList())
+        .page(comments.getNumber())
+        .size(comments.getSize())
+        .totalElements(comments.getTotalElements())
+        .last(comments.isLast())
+        .build();
+  }
+
+  private CommentResponse buildResponse(Comment comment) {
+    return CommentResponse.builder()
+        .id(comment.getId())
+        .content(comment.getContent())
+        .postId(comment.getPost().getId())
+        .userId(comment.getUser().getId())
+        .createdAt(comment.getCreatedAt())
+        .updatedAt(comment.getUpdatedAt())
+        .build();
+  }
+
+  private String extractUserId(String authorizationHeader) {
+    if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+      throw new CustomException(ErrorCode.INVALID_JWT_TOKEN);
+    }
+    String token = authorizationHeader.replace("Bearer ", "");
+    return provider.validateAndGetUserId(token);
+  }
+
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/dto/CommentResponse.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/dto/CommentResponse.java
@@ -1,0 +1,23 @@
+package com.github.shCHO9801.climbing_record_app.community.comment.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentResponse {
+
+  private Long id;
+  private String content;
+  private Long postId;
+  private String userId;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/dto/CreateCommentRequest.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/dto/CreateCommentRequest.java
@@ -1,0 +1,17 @@
+package com.github.shCHO9801.climbing_record_app.community.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateCommentRequest {
+
+  private String content;
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/dto/UpdateCommentRequest.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/dto/UpdateCommentRequest.java
@@ -1,0 +1,14 @@
+package com.github.shCHO9801.climbing_record_app.community.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateCommentRequest {
+  private String comment;
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/dto/UpdateCommentRequest.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/dto/UpdateCommentRequest.java
@@ -10,5 +10,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateCommentRequest {
-  private String comment;
+  private String content;
 }

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/entity/Comment.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/entity/Comment.java
@@ -1,0 +1,61 @@
+package com.github.shCHO9801.climbing_record_app.community.comment.entity;
+
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.Post;
+import com.github.shCHO9801.climbing_record_app.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "comment")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Comment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  private LocalDateTime updatedAt;
+
+  @ManyToOne
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post;
+
+  @ManyToOne
+  @JoinColumn(name = "user_Num", nullable = false)
+  private User user;
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = null;
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/entity/Comment.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/entity/Comment.java
@@ -58,4 +58,12 @@ public class Comment {
   protected void onUpdate() {
     this.updatedAt = LocalDateTime.now();
   }
+
+  public static Comment buildComment(User user, Post post, String content) {
+    return Comment.builder()
+        .content(content)
+        .post(post)
+        .user(user)
+        .build();
+  }
 }

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/repository/CommentRepository.java
@@ -1,0 +1,13 @@
+package com.github.shCHO9801.climbing_record_app.community.comment.repository;
+
+import com.github.shCHO9801.climbing_record_app.community.comment.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+  Page<Comment> getCommentsByPostId(Long postId, Pageable pageable);
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/service/CommentService.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/comment/service/CommentService.java
@@ -1,0 +1,93 @@
+package com.github.shCHO9801.climbing_record_app.community.comment.service;
+
+import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.POST_NOT_FOUND;
+import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.USER_NOT_FOUND;
+
+import com.github.shCHO9801.climbing_record_app.community.comment.dto.CreateCommentRequest;
+import com.github.shCHO9801.climbing_record_app.community.comment.dto.UpdateCommentRequest;
+import com.github.shCHO9801.climbing_record_app.community.comment.entity.Comment;
+import com.github.shCHO9801.climbing_record_app.community.comment.repository.CommentRepository;
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.Post;
+import com.github.shCHO9801.climbing_record_app.community.posting.repository.PostRepository;
+import com.github.shCHO9801.climbing_record_app.exception.CustomException;
+import com.github.shCHO9801.climbing_record_app.exception.ErrorCode;
+import com.github.shCHO9801.climbing_record_app.user.entity.User;
+import com.github.shCHO9801.climbing_record_app.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentService {
+
+  private final CommentRepository commentRepository;
+  private final UserRepository userRepository;
+  private final PostRepository postRepository;
+
+  public Comment createComment(Long postId, String userId, CreateCommentRequest request) {
+
+    User user = userRepository.findByUsername(userId)
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+
+    return commentRepository.save(buildComment(user, post, request));
+  }
+
+  public Page<Comment> getComments(Long postId, Pageable pageable) {
+    return commentRepository.getCommentsByPostId(postId, pageable);
+  }
+
+  public Comment updateComment(String userId, Long commentId, UpdateCommentRequest request) {
+    User user = findUser(userId);
+
+    Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+    if(!postRepository.existsById(comment.getPost().getId())){
+      throw new CustomException(ErrorCode.UNAUTHORIZED_ACTION);
+    }
+
+    if(user.getUserNum() != comment.getUser().getUserNum()) {
+      throw new CustomException(ErrorCode.UNAUTHORIZED_ACTION);
+    }
+
+    comment.setContent(request.getComment());
+    return commentRepository.save(comment);
+  }
+
+  public void deleteComment(String userId, Long commentId) {
+    User user = findUser(userId);
+
+    Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+    if(!postRepository.existsById(comment.getPost().getId())) {
+      throw new CustomException(ErrorCode.UNAUTHORIZED_ACTION);
+    }
+
+    if(user.getUserNum() != comment.getUser().getUserNum()) {
+      throw new CustomException(ErrorCode.UNAUTHORIZED_ACTION);
+    }
+
+    commentRepository.delete(comment);
+  }
+
+  private User findUser(String userId) {
+    return userRepository.findByUsername(userId)
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+  }
+
+  private Comment buildComment(User user, Post post, CreateCommentRequest request) {
+    return Comment.builder()
+        .content(request.getContent())
+        .post(post)
+        .user(user)
+        .build();
+  }
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/controller/PostController.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/controller/PostController.java
@@ -1,5 +1,7 @@
 package com.github.shCHO9801.climbing_record_app.community.posting.controller;
 
+import static com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostResponse.createPostResponse;
+
 import com.github.shCHO9801.climbing_record_app.climbingsession.dto.PagedResponse;
 import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostRequest;
 import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostResponse;
@@ -44,7 +46,8 @@ public class PostController {
     String userId = extractUserId(authorization);
     Post savedPost = postService.createPost(userId, request);
 
-    CreatePostResponse response = createPostResponse(savedPost, "게시글이 성공적으로 생성되었습니다.");
+    CreatePostResponse response =
+        createPostResponse(savedPost, "게시글이 성공적으로 생성되었습니다.");
 
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
@@ -72,7 +75,8 @@ public class PostController {
   ) {
     String userId = extractUserId(authorization);
     Post savedPost = postService.updatePost(userId, postId, request);
-    CreatePostResponse response = createPostResponse(savedPost, "게시글이 성공적으로 수정되었습니다.");
+    CreatePostResponse response =
+        createPostResponse(savedPost, "게시글이 성공적으로 수정되었습니다.");
 
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
@@ -96,27 +100,10 @@ public class PostController {
     return provider.validateAndGetUserId(token);
   }
 
-  private CreatePostResponse createPostResponse(Post post, String message) {
-    return CreatePostResponse.builder()
-        .postId(post.getId())
-        .message(message)
-        .build();
-  }
-
-  private GetPostResponse getPostResponse(Post post) {
-    return GetPostResponse.builder()
-        .id(post.getId())
-        .title(post.getTitle())
-        .content(post.getContent())
-        .userId(post.getUser().getId())
-        .gymId(post.getClimbingGym().getId())
-        .build();
-  }
-
   private PagedResponse<GetPostResponse> createPagedResponse(Page<Post> posts) {
     return PagedResponse.<GetPostResponse>builder()
         .content(posts.getContent().stream()
-            .map(this::getPostResponse)
+            .map(GetPostResponse::getPostResponse)
             .toList())
         .page(posts.getNumber())
         .size(posts.getSize())

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/controller/PostController.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/controller/PostController.java
@@ -1,0 +1,50 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.controller;
+
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostRequest;
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostResponse;
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.Post;
+import com.github.shCHO9801.climbing_record_app.community.posting.service.PostService;
+import com.github.shCHO9801.climbing_record_app.exception.CustomException;
+import com.github.shCHO9801.climbing_record_app.exception.ErrorCode;
+import com.github.shCHO9801.climbing_record_app.util.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+  private final JwtTokenProvider provider;
+  private final PostService postService;
+
+  @PostMapping
+  public ResponseEntity<CreatePostResponse> createPost(
+      @RequestHeader("Authorization") String authorization,
+      @RequestBody CreatePostRequest request
+  ) {
+    String userId = extractUserId(authorization);
+    Post savedPost = postService.createPost(userId, request);
+
+    CreatePostResponse response = CreatePostResponse.builder()
+        .postId(savedPost.getId())
+        .message("게시글이 성공적으로 생성되었습니다.")
+        .build();
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  private String extractUserId(String authorizationHeader) {
+    if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+      throw new CustomException(ErrorCode.INVALID_JWT_TOKEN);
+    }
+    String token = authorizationHeader.replace("Bearer ", "");
+    return provider.validateAndGetUserId(token);
+  }
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/controller/PostController.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/controller/PostController.java
@@ -1,19 +1,31 @@
 package com.github.shCHO9801.climbing_record_app.community.posting.controller;
 
+import com.github.shCHO9801.climbing_record_app.climbingsession.dto.PagedResponse;
 import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostRequest;
 import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostResponse;
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.UpdatePostRequest;
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.GetPostResponse;
 import com.github.shCHO9801.climbing_record_app.community.posting.entity.Post;
 import com.github.shCHO9801.climbing_record_app.community.posting.service.PostService;
 import com.github.shCHO9801.climbing_record_app.exception.CustomException;
 import com.github.shCHO9801.climbing_record_app.exception.ErrorCode;
 import com.github.shCHO9801.climbing_record_app.util.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,12 +44,48 @@ public class PostController {
     String userId = extractUserId(authorization);
     Post savedPost = postService.createPost(userId, request);
 
-    CreatePostResponse response = CreatePostResponse.builder()
-        .postId(savedPost.getId())
-        .message("게시글이 성공적으로 생성되었습니다.")
-        .build();
+    CreatePostResponse response = createPostResponse(savedPost, "게시글이 성공적으로 생성되었습니다.");
 
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @GetMapping
+  public ResponseEntity<PagedResponse<GetPostResponse>> getAllPosts(
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size
+  ) {
+    Pageable pageable =
+        PageRequest.of(page, size, Sort.by("createdAt").descending());
+
+    Page<Post> posts = postService.getAllPosts(pageable);
+
+    PagedResponse<GetPostResponse> response = createPagedResponse(posts);
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+
+  // 게시글 수정
+  @PutMapping("/{postId}")
+  public ResponseEntity<CreatePostResponse> updatePost(
+      @RequestHeader("Authorization") String authorization,
+      @PathVariable Long postId,
+      @RequestBody UpdatePostRequest request
+  ) {
+    String userId = extractUserId(authorization);
+    Post savedPost = postService.updatePost(userId, postId, request);
+    CreatePostResponse response = createPostResponse(savedPost, "게시글이 성공적으로 수정되었습니다.");
+
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+
+  // 게시글 삭제
+  @DeleteMapping("/{postId}")
+  public ResponseEntity<Void> deletePost(
+      @RequestHeader("Authorization") String authorization,
+      @PathVariable Long postId
+  ) {
+    String userId = extractUserId(authorization);
+    postService.deletePost(userId, postId);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
   private String extractUserId(String authorizationHeader) {
@@ -46,5 +94,34 @@ public class PostController {
     }
     String token = authorizationHeader.replace("Bearer ", "");
     return provider.validateAndGetUserId(token);
+  }
+
+  private CreatePostResponse createPostResponse(Post post, String message) {
+    return CreatePostResponse.builder()
+        .postId(post.getId())
+        .message(message)
+        .build();
+  }
+
+  private GetPostResponse getPostResponse(Post post) {
+    return GetPostResponse.builder()
+        .id(post.getId())
+        .title(post.getTitle())
+        .content(post.getContent())
+        .userId(post.getUser().getId())
+        .gymId(post.getClimbingGym().getId())
+        .build();
+  }
+
+  private PagedResponse<GetPostResponse> createPagedResponse(Page<Post> posts) {
+    return PagedResponse.<GetPostResponse>builder()
+        .content(posts.getContent().stream()
+            .map(this::getPostResponse)
+            .toList())
+        .page(posts.getNumber())
+        .size(posts.getSize())
+        .totalElements(posts.getTotalElements())
+        .last(posts.isLast())
+        .build();
   }
 }

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/dto/CreatePostRequest.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/dto/CreatePostRequest.java
@@ -1,0 +1,23 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.dto;
+
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreatePostRequest {
+
+  private String title;
+  private String content;
+  private Long climbingGymId;
+  @Size(max = 10, message = "첨부 가능한 미디어는 최대 10개입니다.")
+  private List<PostMediaRequest> media;
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/dto/CreatePostResponse.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/dto/CreatePostResponse.java
@@ -1,0 +1,17 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreatePostResponse {
+  private Long postId;
+  private String message;
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/dto/CreatePostResponse.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/dto/CreatePostResponse.java
@@ -1,5 +1,6 @@
 package com.github.shCHO9801.climbing_record_app.community.posting.dto;
 
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.Post;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,4 +15,11 @@ import lombok.Setter;
 public class CreatePostResponse {
   private Long postId;
   private String message;
+
+  public static CreatePostResponse createPostResponse(Post post, String message) {
+    return CreatePostResponse.builder()
+        .postId(post.getId())
+        .message(message)
+        .build();
+  }
 }

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/dto/PostMediaRequest.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/dto/PostMediaRequest.java
@@ -1,0 +1,18 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.dto;
+
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.MediaType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostMediaRequest {
+  private String mediaUrl;
+  private MediaType mediaType;
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/dto/UpdatePostRequest.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/dto/UpdatePostRequest.java
@@ -1,0 +1,22 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdatePostRequest {
+
+  @NotBlank(message = "제목은 필수입니다.")
+  private String title;
+
+  @NotBlank(message = "내용은 필수입니다.")
+  private String content;
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/GetPostResponse.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/GetPostResponse.java
@@ -1,0 +1,21 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetPostResponse {
+
+  private Long id;
+  private String title;
+  private String content;
+  private String userId;
+  private Long gymId;
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/GetPostResponse.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/GetPostResponse.java
@@ -18,4 +18,14 @@ public class GetPostResponse {
   private String content;
   private String userId;
   private Long gymId;
+
+  public static GetPostResponse getPostResponse(Post post) {
+    return GetPostResponse.builder()
+        .id(post.getId())
+        .title(post.getTitle())
+        .content(post.getContent())
+        .userId(post.getUser().getId())
+        .gymId(post.getClimbingGym().getId())
+        .build();
+  }
 }

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/MediaType.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/MediaType.java
@@ -1,0 +1,5 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.entity;
+
+public enum MediaType {
+  IMAGE, VIDEO
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/Post.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/Post.java
@@ -1,6 +1,7 @@
 package com.github.shCHO9801.climbing_record_app.community.posting.entity;
 
 import com.github.shCHO9801.climbing_record_app.climbinggym.entity.ClimbingGym;
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostRequest;
 import com.github.shCHO9801.climbing_record_app.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -61,5 +62,15 @@ public class Post {
   @PreUpdate
   protected void onUpdate() {
     this.updatedAt = LocalDateTime.now();
+  }
+
+  public static Post buildPost(User user, ClimbingGym gym, CreatePostRequest request) {
+    return Post.builder()
+        .title(request.getTitle())
+        .content(request.getContent())
+        .user(user)
+        .climbingGym(gym)
+        .createdAt(LocalDateTime.now())
+        .build();
   }
 }

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/Post.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/Post.java
@@ -1,0 +1,65 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.entity;
+
+import com.github.shCHO9801.climbing_record_app.climbinggym.entity.ClimbingGym;
+import com.github.shCHO9801.climbing_record_app.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "posts")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Post {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_num", nullable = false)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "climbing_gym_id", nullable = false)
+  private ClimbingGym climbingGym;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column
+  private LocalDateTime updatedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/PostMedia.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/PostMedia.java
@@ -1,0 +1,43 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "post_media")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostMedia {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String mediaUrl;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private MediaType mediaType;
+
+  @ManyToOne
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post;
+
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/PostMedia.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/entity/PostMedia.java
@@ -1,5 +1,6 @@
 package com.github.shCHO9801.climbing_record_app.community.posting.entity;
 
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.PostMediaRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -40,4 +41,11 @@ public class PostMedia {
   @JoinColumn(name = "post_id", nullable = false)
   private Post post;
 
+  public static PostMedia buildPostMedia(Post post, PostMediaRequest request) {
+    return PostMedia.builder()
+        .mediaUrl(request.getMediaUrl())
+        .mediaType(request.getMediaType())
+        .post(post)
+        .build();
+  }
 }

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/repository/PostMediaRepository.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/repository/PostMediaRepository.java
@@ -1,0 +1,8 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.repository;
+
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.PostMedia;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostMediaRepository extends JpaRepository<Long, PostMedia> {
+
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/repository/PostMediaRepository.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/repository/PostMediaRepository.java
@@ -2,7 +2,9 @@ package com.github.shCHO9801.climbing_record_app.community.posting.repository;
 
 import com.github.shCHO9801.climbing_record_app.community.posting.entity.PostMedia;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-public interface PostMediaRepository extends JpaRepository<Long, PostMedia> {
+@Repository
+public interface PostMediaRepository extends JpaRepository<PostMedia, Long> {
 
 }

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/repository/PostRepository.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/repository/PostRepository.java
@@ -1,0 +1,10 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.repository;
+
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/service/PostService.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/service/PostService.java
@@ -1,0 +1,63 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.service;
+
+import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.USER_NOT_FOUND;
+
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostRequest;
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.PostMediaRequest;
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.Post;
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.PostMedia;
+import com.github.shCHO9801.climbing_record_app.community.posting.repository.PostMediaRepository;
+import com.github.shCHO9801.climbing_record_app.community.posting.repository.PostRepository;
+import com.github.shCHO9801.climbing_record_app.exception.CustomException;
+import com.github.shCHO9801.climbing_record_app.user.entity.User;
+import com.github.shCHO9801.climbing_record_app.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+  private final PostRepository postRepository;
+  private final PostMediaRepository postMediaRepository;
+  private final UserRepository userRepository;
+
+  //TODO : 추후 AWS S3 업로드 서비스
+
+  @Transactional
+  public Post createPost(String userId, CreatePostRequest request) {
+    User user = userRepository.findByUsername(userId)
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+    Post post = postRepository.save(buildPost(user, request));
+
+    if(request.getMedia() != null && !request.getMedia().isEmpty()) {
+      request.getMedia().forEach(mediaDto -> {
+        PostMedia media = buildPostMedia(post, mediaDto);
+        postMediaRepository.save(media);
+      });
+    }
+
+    return post;
+  }
+
+  private PostMedia buildPostMedia(Post post, PostMediaRequest mediaDto) {
+    return PostMedia.builder()
+        .mediaUrl(mediaDto.getMediaUrl())
+        .mediaType(mediaDto.getMediaType())
+        .post(post)
+        .build();
+  }
+
+  private Post buildPost(User user, CreatePostRequest request) {
+    return Post.builder()
+        .title(request.getTitle())
+        .content(request.getContent())
+        .user(user)
+        .createdAt(LocalDateTime.now())
+        .build();
+  }
+
+}

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/service/PostService.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/community/posting/service/PostService.java
@@ -1,9 +1,16 @@
 package com.github.shCHO9801.climbing_record_app.community.posting.service;
 
+import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.CLIMBING_GYM_NOT_FOUND;
+import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.POST_NOT_FOUND;
+import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.UNAUTHORIZED_ACTION;
 import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.USER_NOT_FOUND;
 
+import com.github.shCHO9801.climbing_record_app.climbinggym.entity.ClimbingGym;
+import com.github.shCHO9801.climbing_record_app.climbinggym.repository.ClimbingGymRepository;
 import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostRequest;
 import com.github.shCHO9801.climbing_record_app.community.posting.dto.PostMediaRequest;
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.UpdatePostRequest;
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.GetPostResponse;
 import com.github.shCHO9801.climbing_record_app.community.posting.entity.Post;
 import com.github.shCHO9801.climbing_record_app.community.posting.entity.PostMedia;
 import com.github.shCHO9801.climbing_record_app.community.posting.repository.PostMediaRepository;
@@ -14,6 +21,8 @@ import com.github.shCHO9801.climbing_record_app.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,6 +32,7 @@ public class PostService {
   private final PostRepository postRepository;
   private final PostMediaRepository postMediaRepository;
   private final UserRepository userRepository;
+  private final ClimbingGymRepository climbingGymRepository;
 
   //TODO : 추후 AWS S3 업로드 서비스
 
@@ -31,15 +41,61 @@ public class PostService {
     User user = userRepository.findByUsername(userId)
         .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-    Post post = postRepository.save(buildPost(user, request));
+    ClimbingGym gym = climbingGymRepository.findById(request.getClimbingGymId())
+        .orElseThrow(() -> new CustomException(CLIMBING_GYM_NOT_FOUND));
 
-    if(request.getMedia() != null && !request.getMedia().isEmpty()) {
+    Post post = postRepository.save(buildPost(user, gym, request));
+
+    if (request.getMedia() != null && !request.getMedia().isEmpty()) {
       request.getMedia().forEach(mediaDto -> {
         PostMedia media = buildPostMedia(post, mediaDto);
         postMediaRepository.save(media);
       });
     }
 
+    return post;
+  }
+
+  public Page<Post> getAllPosts(Pageable pageable) {
+    return postRepository.findAll(pageable);
+  }
+
+  public GetPostResponse getPost(Long id) {
+    Post post = postRepository.findById(id)
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+    return getPostResponse(post);
+  }
+
+
+
+  public Post updatePost(String userId, Long postId, UpdatePostRequest request) {
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+
+    if (!post.getUser().getId().equals(userId)) {
+      throw new CustomException(UNAUTHORIZED_ACTION);
+    }
+
+    Post updatePost = setUpdatePost(request, post);
+
+    return postRepository.save(updatePost);
+  }
+
+  public void deletePost(String userId, Long postId) {
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+
+    if (!post.getUser().getId().equals(userId)) {
+      throw new CustomException(UNAUTHORIZED_ACTION);
+    }
+
+    postRepository.delete(post);
+  }
+
+  private Post setUpdatePost(UpdatePostRequest request, Post post) {
+    post.setTitle(request.getTitle());
+    post.setContent(request.getContent());
+    post.setUpdatedAt(LocalDateTime.now());
     return post;
   }
 
@@ -51,12 +107,23 @@ public class PostService {
         .build();
   }
 
-  private Post buildPost(User user, CreatePostRequest request) {
+  private Post buildPost(User user, ClimbingGym gym, CreatePostRequest request) {
     return Post.builder()
         .title(request.getTitle())
         .content(request.getContent())
         .user(user)
+        .climbingGym(gym)
         .createdAt(LocalDateTime.now())
+        .build();
+  }
+
+  private GetPostResponse getPostResponse(Post post) {
+    return GetPostResponse.builder()
+        .id(post.getId())
+        .title(post.getTitle())
+        .content(post.getContent())
+        .userId(post.getUser().getId())
+        .gymId(post.getClimbingGym().getId())
         .build();
   }
 

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/config/SecurityConfig.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                     "/api/user-monthly-stats/**",
                     "/api/profile/**",
                     "/api/posts/**",
+                    "/api/comments/**",
                     "/v3/api-docs/**",
                     "/swagger-ui/**",
                     "/swagger-ui.html").permitAll()

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/config/SecurityConfig.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                     "/api/climbing-session/**",
                     "/api/user-monthly-stats/**",
                     "/api/profile/**",
+                    "/api/posts/**",
                     "/v3/api-docs/**",
                     "/swagger-ui/**",
                     "/swagger-ui.html").permitAll()

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/exception/ErrorCode.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/exception/ErrorCode.java
@@ -19,7 +19,9 @@ public enum ErrorCode {
   CLIMBING_GYM_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 클라이밍장 입니다."),
   CLIMBING_GYM_NOT_FOUND(HttpStatus.BAD_REQUEST, "클라이밍장을 찾을 수 없습니다."),
   USER_MONTHLY_STATS_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 유저의 기록이 없습니다."),
-  INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "JWT 토큰이 존재하지 않거나 형식이 잘못되었습니다.");
+  INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "JWT 토큰이 존재하지 않거나 형식이 잘못되었습니다."),
+  POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "Post를 찾을 수 없습니다."),
+  UNAUTHORIZED_ACTION(HttpStatus.BAD_REQUEST, "작성자만 게시글을 수정, 삭제할 수 있습니다.");
 
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/github/shCHO9801/climbing_record_app/exception/ErrorCode.java
+++ b/src/main/java/com/github/shCHO9801/climbing_record_app/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
   USER_MONTHLY_STATS_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 유저의 기록이 없습니다."),
   INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "JWT 토큰이 존재하지 않거나 형식이 잘못되었습니다."),
   POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "Post를 찾을 수 없습니다."),
-  UNAUTHORIZED_ACTION(HttpStatus.BAD_REQUEST, "작성자만 게시글을 수정, 삭제할 수 있습니다.");
+  UNAUTHORIZED_ACTION(HttpStatus.BAD_REQUEST, "작성자만 게시글을 수정, 삭제할 수 있습니다."),
+  COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "Comment를 찾을 수 없습니다.");
 
 
   private final HttpStatus httpStatus;

--- a/src/test/java/com/github/shCHO9801/climbing_record_app/community/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/github/shCHO9801/climbing_record_app/community/comment/controller/CommentControllerTest.java
@@ -1,0 +1,217 @@
+package com.github.shCHO9801.climbing_record_app.community.comment.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.shCHO9801.climbing_record_app.climbinggym.dto.CreateGymRequest;
+import com.github.shCHO9801.climbing_record_app.climbinggym.dto.CreateGymResponse;
+import com.github.shCHO9801.climbing_record_app.climbinggym.entity.ClimbingGym;
+import com.github.shCHO9801.climbing_record_app.climbinggym.repository.ClimbingGymRepository;
+import com.github.shCHO9801.climbing_record_app.climbinggym.service.ClimbingGymService;
+import com.github.shCHO9801.climbing_record_app.community.comment.dto.CreateCommentRequest;
+import com.github.shCHO9801.climbing_record_app.community.comment.dto.UpdateCommentRequest;
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostRequest;
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.Post;
+import com.github.shCHO9801.climbing_record_app.community.posting.service.PostService;
+import com.github.shCHO9801.climbing_record_app.user.dto.RegisterRequest;
+import com.github.shCHO9801.climbing_record_app.user.entity.User;
+import com.github.shCHO9801.climbing_record_app.user.repository.UserRepository;
+import com.github.shCHO9801.climbing_record_app.user.service.UserService;
+import com.github.shCHO9801.climbing_record_app.util.JwtTokenProvider;
+import com.github.shCHO9801.climbing_record_app.util.JwtUtil;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@ActiveProfiles("testContainer")
+@Testcontainers
+@AutoConfigureMockMvc
+@Transactional
+@DisplayName("댓글 인테그레이션 테스트")
+class CommentControllerTest {
+
+  @Container
+  private static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.28")
+      .withDatabaseName("testdb")
+      .withUsername("testuser")
+      .withPassword("testpass");
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", mysql::getJdbcUrl);
+    registry.add("spring.datasource.username", mysql::getUsername);
+    registry.add("spring.datasource.password", mysql::getPassword);
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+    registry.add("spring.jpa.properties.hibernate.dialect",
+        () -> "org.hibernate.dialect.MySQL8Dialect");
+  }
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private JwtUtil jwtUtil;
+
+  @Autowired
+  private JwtTokenProvider jwtTokenProvider;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private UserService userService;
+
+  @Autowired
+  private ClimbingGymRepository climbingGymRepository;
+
+  @Autowired
+  private ClimbingGymService climbingGymService;
+
+  private String token;
+  private User user;
+  private Post post;
+  private ClimbingGym gym;
+  @Autowired
+  private PostService postService;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    RegisterRequest registerRequest = RegisterRequest.builder()
+        .username("testUser")
+        .password("testPassword")
+        .email("test@test.com")
+        .build();
+
+    userService.registerUser(registerRequest);
+    user = userRepository.findByUsername("testUser")
+        .orElse(null);
+
+    token = "Bearer " + jwtUtil.generateToken(user.getId(), user.getRole().toString());
+
+    CreateGymRequest createGymRequest = CreateGymRequest.builder()
+        .name("testGym")
+        .longitude(123.0)
+        .latitude(4566.0)
+        .price(20000)
+        .build();
+    CreateGymResponse createGymResponse
+        = climbingGymService.createClimbingGym(createGymRequest);
+    gym = climbingGymRepository.findById(createGymResponse.getId())
+        .orElse(null);
+
+    CreatePostRequest createPostRequest = CreatePostRequest.builder()
+        .title("testPost")
+        .content("testContent")
+        .climbingGymId(gym.getId())
+        .build();
+
+    post = postService.createPost(user.getId(), createPostRequest);
+  }
+
+  @Test
+  @DisplayName("댓글 생성 성공")
+  void createCommentSuccess() throws Exception {
+    CreateCommentRequest request = CreateCommentRequest.builder()
+        .content("새로운 댓글.")
+        .build();
+
+    mockMvc.perform(post("/api/posts/{postId}/comments", post.getId())
+            .header("Authorization", token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.content").value("새로운 댓글."));
+  }
+
+  @Test
+  @DisplayName("댓글 목록 조회 성공")
+  void getCommentsSuccess() throws Exception {
+    CreateCommentRequest commentRequest = CreateCommentRequest.builder()
+        .content("댓글 1")
+        .build();
+    mockMvc.perform(post("/api/posts/{postId}/comments", post.getId())
+            .header("Authorization", token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(commentRequest)))
+        .andExpect(status().isCreated());
+
+    mockMvc.perform(get("/api/posts/{postId}/comments", post.getId())
+            .param("page", "0")
+            .param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.totalElements").value(1))
+        .andExpect(jsonPath("$.content[0].content").value("댓글 1"));
+  }
+
+  @Test
+  @DisplayName("댓글 수정 성공")
+  void updateCommentSuccess() throws Exception {
+    CreateCommentRequest commentRequest = CreateCommentRequest.builder()
+        .content("원래 댓글")
+        .build();
+    String responseContent = mockMvc.perform(post("/api/posts/{postId}/comments", post.getId())
+            .header("Authorization", token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(commentRequest)))
+        .andExpect(status().isCreated())
+        .andReturn().getResponse().getContentAsString();
+
+    System.out.println(responseContent);
+
+    responseContent = responseContent.substring(1, responseContent.length() - 1);
+    Long commentId = Long.parseLong(responseContent.split(",")[0].split(":")[1]);
+
+    UpdateCommentRequest updateRequest = UpdateCommentRequest.builder()
+        .content("수정된 댓글")
+        .build();
+
+    mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", post.getId(), commentId)
+            .header("Authorization", token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").value("수정된 댓글"));
+  }
+
+  @Test
+  @DisplayName("댓글 삭제 성공")
+  void deleteCommentSuccess() throws Exception {
+    CreateCommentRequest createRequest = CreateCommentRequest.builder()
+        .content("삭제할 댓글")
+        .build();
+    String responseContent = mockMvc.perform(post("/api/posts/{postId}/comments", post.getId())
+            .header("Authorization", token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(createRequest)))
+        .andExpect(status().isCreated())
+        .andReturn().getResponse().getContentAsString();
+
+    Long commentId = Long.parseLong(responseContent.split(",")[0].split(":")[1]);
+
+    mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", post.getId(), commentId)
+            .header("Authorization", token))
+        .andExpect(status().isNoContent());
+  }
+}

--- a/src/test/java/com/github/shCHO9801/climbing_record_app/community/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/github/shCHO9801/climbing_record_app/community/comment/controller/CommentControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.shCHO9801.climbing_record_app.climbinggym.dto.CreateGymRequest;
 import com.github.shCHO9801.climbing_record_app.climbinggym.dto.CreateGymResponse;
@@ -180,8 +181,8 @@ class CommentControllerTest {
 
     System.out.println(responseContent);
 
-    responseContent = responseContent.substring(1, responseContent.length() - 1);
-    Long commentId = Long.parseLong(responseContent.split(",")[0].split(":")[1]);
+    JsonNode node = objectMapper.readTree(responseContent);
+    Long commentId = node.get("id").asLong();
 
     UpdateCommentRequest updateRequest = UpdateCommentRequest.builder()
         .content("수정된 댓글")
@@ -208,7 +209,8 @@ class CommentControllerTest {
         .andExpect(status().isCreated())
         .andReturn().getResponse().getContentAsString();
 
-    Long commentId = Long.parseLong(responseContent.split(",")[0].split(":")[1]);
+    JsonNode node = objectMapper.readTree(responseContent);
+    Long commentId = node.get("id").asLong();
 
     mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", post.getId(), commentId)
             .header("Authorization", token))

--- a/src/test/java/com/github/shCHO9801/climbing_record_app/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/github/shCHO9801/climbing_record_app/community/comment/service/CommentServiceTest.java
@@ -1,0 +1,294 @@
+package com.github.shCHO9801.climbing_record_app.community.comment.service;
+
+import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.POST_NOT_FOUND;
+import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.UNAUTHORIZED_ACTION;
+import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.USER_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.shCHO9801.climbing_record_app.climbinggym.entity.ClimbingGym;
+import com.github.shCHO9801.climbing_record_app.community.comment.dto.CreateCommentRequest;
+import com.github.shCHO9801.climbing_record_app.community.comment.dto.UpdateCommentRequest;
+import com.github.shCHO9801.climbing_record_app.community.comment.entity.Comment;
+import com.github.shCHO9801.climbing_record_app.community.comment.repository.CommentRepository;
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.Post;
+import com.github.shCHO9801.climbing_record_app.community.posting.repository.PostRepository;
+import com.github.shCHO9801.climbing_record_app.exception.CustomException;
+import com.github.shCHO9801.climbing_record_app.user.entity.User;
+import com.github.shCHO9801.climbing_record_app.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DisplayName("댓글 유닛 테스트")
+class CommentServiceTest {
+
+  @InjectMocks
+  private CommentService commentService;
+
+  @Mock
+  private CommentRepository commentRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private PostRepository postRepository;
+
+  private User user;
+  private Post post;
+  private Comment comment;
+  private ClimbingGym gym;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    user = User.builder()
+        .userNum(1L)
+        .id("testUser")
+        .password("testPassword")
+        .build();
+
+    gym = ClimbingGym.builder()
+        .id(1L)
+        .name("testGym")
+        .price(20000)
+        .build();
+
+    post = Post.builder()
+        .id(1L)
+        .title("testTitle")
+        .content("testContent")
+        .user(user)
+        .build();
+
+    comment = Comment.builder()
+        .id(1L)
+        .content("testCommentContent")
+        .user(user)
+        .post(post)
+        .build();
+  }
+
+  @Test
+  @DisplayName("댓글 생성 성공")
+  void createCommentSuccess() {
+    //given
+    CreateCommentRequest commentRequest
+        = buildCommentRequest("testCommentContent");
+
+    when(userRepository.findByUsername(user.getId()))
+        .thenReturn(Optional.of(user));
+    when(postRepository.findById(post.getId()))
+        .thenReturn(Optional.of(post));
+    when(commentRepository.save(any(Comment.class)))
+        .thenReturn(comment);
+
+    //when
+    Comment create = commentService.createComment(post.getId(), user.getId(), commentRequest);
+
+    //then
+    assertNotNull(create);
+    assertEquals(comment.getId(), create.getId());
+    assertEquals(user.getId(), create.getUser().getId());
+    assertEquals(comment.getContent(), create.getContent());
+    assertEquals(commentRequest.getContent(), create.getContent());
+    verify(commentRepository, times(1))
+        .save(any(Comment.class));
+  }
+
+  @Test
+  @DisplayName("뎃글 생성 실패 - 유저 미존재")
+  void createCommentFailUserNotFound() {
+    //given
+    CreateCommentRequest commentRequest
+        = buildCommentRequest("testCommentContent");
+
+    when(userRepository.findByUsername("nonExistentUser"))
+        .thenReturn(Optional.empty());
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> commentService.createComment(post.getId(), "nonExistentUser", commentRequest));
+
+    //then
+    assertEquals(exception.getErrorCode(), USER_NOT_FOUND);
+    verify(commentRepository, never()).save(any(Comment.class));
+  }
+
+  @Test
+  @DisplayName("댓글 생성 실패 - 게시글 미존재")
+  void createCommentFailPostNotFound() {
+    //given
+    CreateCommentRequest commentRequest
+        = buildCommentRequest("testCommentContent");
+
+    when(userRepository.findByUsername(user.getId()))
+        .thenReturn(Optional.of(user));
+    when(postRepository.findById(9999L))
+        .thenReturn(Optional.empty());
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> commentService.createComment(9999L, user.getId(), commentRequest));
+
+    //then
+    assertEquals(exception.getErrorCode(), POST_NOT_FOUND);
+    verify(commentRepository, never()).save(any(Comment.class));
+  }
+
+  @Test
+  @DisplayName("게시글 수정 성공")
+  void updateCommentSuccess() {
+    //given
+    UpdateCommentRequest updateRequest =
+        buildUpdateRequeat("수정된 댓글");
+
+    when(userRepository.findByUsername(user.getId()))
+        .thenReturn(Optional.of(user));
+    when(commentRepository.findById(comment.getId()))
+        .thenReturn(Optional.of(comment));
+    when(postRepository.existsById(post.getId()))
+        .thenReturn(true);
+    when(commentRepository.save(any(Comment.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    //when
+    Comment updated
+        = commentService.updateComment(user.getId(), comment.getId(), updateRequest);
+
+    //then
+    assertNotNull(updated);
+    assertEquals(comment.getId(), updated.getId());
+    assertEquals(updateRequest.getComment(), updated.getContent());
+  }
+
+  @Test
+  @DisplayName("댓글 수정 실패 - 권한 없음")
+  void updateCommentFailUnauthorized() {
+    //given
+    UpdateCommentRequest updateRequest
+        = buildUpdateRequeat("수정된 댓글");
+
+    User anotherUser = User.builder()
+        .userNum(2L)
+        .id("anotherUser")
+        .password("anotherPassword")
+        .build();
+
+    when(commentRepository.findById(comment.getId()))
+        .thenReturn(Optional.of(comment));
+    when(userRepository.findByUsername(anotherUser.getId()))
+        .thenReturn(Optional.of(anotherUser));
+    when(postRepository.existsById(post.getId()))
+        .thenReturn(true);
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> commentService.updateComment(anotherUser.getId(), comment.getId(), updateRequest));
+
+    //then
+    assertEquals(exception.getErrorCode(), UNAUTHORIZED_ACTION);
+    verify(commentRepository, never()).save(any(Comment.class));
+  }
+
+  @Test
+  @DisplayName("댓글 삭제 성공")
+  void deleteCommentSuccess() {
+    //given
+    when(userRepository.findByUsername(user.getId()))
+        .thenReturn(Optional.of(user));
+    when(commentRepository.findById(comment.getId()))
+        .thenReturn(Optional.of(comment));
+    when(postRepository.existsById(post.getId()))
+        .thenReturn(true);
+
+    //when&then
+    commentService.deleteComment(user.getId(), comment.getId());
+    verify(commentRepository, times(1))
+        .delete(any(Comment.class));
+  }
+
+  @Test
+  @DisplayName("댓글 삭제 실패 - 권한 없음")
+  void deleteCommentFailUnauthorized() {
+    //given
+    User anotherUser = User.builder()
+        .userNum(2L)
+        .id("anotherUser")
+        .password("anotherPassword")
+        .build();
+
+    when(userRepository.findByUsername(anotherUser.getId()))
+        .thenReturn(Optional.of(anotherUser));
+    when(commentRepository.findById(comment.getId()))
+        .thenReturn(Optional.of(comment));
+    when(postRepository.existsById(post.getId()))
+        .thenReturn(true);
+
+    //when&then
+    CustomException exception = assertThrows(CustomException.class,
+        () -> commentService.deleteComment(anotherUser.getId(), comment.getId()));
+    assertEquals(exception.getErrorCode(), UNAUTHORIZED_ACTION);
+    verify(commentRepository, never())
+        .delete(any(Comment.class));
+  }
+
+  @Test
+  @DisplayName("댓글 목록 조회 성공")
+  void getCommentsSuccess() {
+      //given
+    Pageable pageable = PageRequest.of(0, 10);
+    List<Comment> commentList = Arrays.asList(comment,
+        Comment.builder()
+            .id(2L)
+            .content("2번째")
+            .createdAt(LocalDateTime.now())
+            .user(user)
+            .post(post)
+            .build());
+    Page<Comment> commentPage = new PageImpl<>(commentList, pageable, commentList.size());
+
+    when(commentRepository.getCommentsByPostId(post.getId(), pageable))
+    .thenReturn(commentPage);
+
+      //when
+    Page<Comment> result = commentService.getComments(post.getId(), pageable);
+
+      //then
+    assertNotNull(result);
+    assertEquals(2, result.getTotalElements());
+    assertEquals(comment, result.getContent().get(0));
+    assertEquals("2번째", result.getContent().get(1).getContent());
+  }
+
+  private UpdateCommentRequest buildUpdateRequeat(String comment) {
+    return UpdateCommentRequest.builder()
+        .comment(comment)
+        .build();
+  }
+
+  private CreateCommentRequest buildCommentRequest(String content) {
+    return CreateCommentRequest.builder()
+        .content(content)
+        .build();
+  }
+}

--- a/src/test/java/com/github/shCHO9801/climbing_record_app/community/posting/controller/PostControllerTest.java
+++ b/src/test/java/com/github/shCHO9801/climbing_record_app/community/posting/controller/PostControllerTest.java
@@ -1,0 +1,166 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.shCHO9801.climbing_record_app.climbinggym.dto.CreateGymRequest;
+import com.github.shCHO9801.climbing_record_app.climbinggym.entity.ClimbingGym;
+import com.github.shCHO9801.climbing_record_app.climbinggym.repository.ClimbingGymRepository;
+import com.github.shCHO9801.climbing_record_app.climbinggym.service.ClimbingGymService;
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostRequest;
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.UpdatePostRequest;
+import com.github.shCHO9801.climbing_record_app.user.dto.RegisterRequest;
+import com.github.shCHO9801.climbing_record_app.user.entity.Role;
+import com.github.shCHO9801.climbing_record_app.user.entity.User;
+import com.github.shCHO9801.climbing_record_app.user.repository.UserRepository;
+import com.github.shCHO9801.climbing_record_app.user.service.UserService;
+import com.github.shCHO9801.climbing_record_app.util.JwtUtil;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("testH2")
+@DisplayName("게시글 인테그레이션 테스트")
+class PostControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private JwtUtil jwtUtil;
+
+  @Autowired
+  private UserService userService;
+
+  @Autowired
+  private ClimbingGymService climbingGymService;
+
+  private String token;
+  private User user;
+  private ClimbingGym gym;
+  @Autowired
+  private UserRepository userRepository;
+  @Autowired
+  private ClimbingGymRepository climbingGymRepository;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    RegisterRequest registerRequest = RegisterRequest.builder()
+        .username("testUser")
+        .email("test@test.com")
+        .password("testPassword")
+        .build();
+
+    userService.registerUser(registerRequest);
+
+    CreateGymRequest createGymRequest = CreateGymRequest.builder()
+        .name("testGym")
+        .latitude(123.0)
+        .longitude(456.0)
+        .price(20000)
+        .build();
+
+    climbingGymService.createClimbingGym(createGymRequest);
+
+    user = userRepository.findByUsername("testUser").orElseThrow();
+    gym = climbingGymRepository.findByName("testGym");
+
+    token = "Bearer " + jwtUtil.generateToken("testUser", Role.USER.toString());
+  }
+
+  @Test
+  @DisplayName("게시글 생성 및 조회 성공")
+  void createAndGetPostSuccess() throws Exception {
+    CreatePostRequest createPostRequest = CreatePostRequest.builder()
+        .title("title")
+        .content("content")
+        .climbingGymId(gym.getId())
+        .media(null)
+        .build();
+
+    String createResponse = mockMvc.perform(post("/api/posts")
+            .header("Authorization", token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(createPostRequest)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.postId").isNumber())
+        .andExpect(jsonPath("$.message").value("게시글이 성공적으로 생성되었습니다."))
+        .andReturn()
+        .getResponse()
+        .getContentAsString();
+
+    mockMvc.perform(get("/api/posts")
+            .param("page", "0")
+            .param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].title").value("title"))
+        .andExpect(jsonPath("$.content[0].content").value("content"))
+        .andExpect(jsonPath("$.totalElements").value("1"));
+  }
+
+  @Test
+  @DisplayName("게시글 수정 및 삭제 성공")
+  void updateAndDeletePostSuccess() throws Exception {
+    CreatePostRequest createRequest = CreatePostRequest.builder()
+        .title("Original Title")
+        .content("Original Content")
+        .climbingGymId(1L)
+        .media(null)
+        .build();
+
+    String createResponse = mockMvc.perform(post("/api/posts")
+            .header("Authorization", token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(createRequest)))
+        .andExpect(status().isCreated())
+        .andReturn()
+        .getResponse()
+        .getContentAsString();
+
+    StringBuilder sb = new StringBuilder();
+    for (char c : createResponse.toCharArray()) {
+      if (Character.isDigit(c)) {
+        sb.append(c);
+      }
+    }
+
+    Long postId = Long.parseLong(sb.toString());
+
+    UpdatePostRequest updateRequest = UpdatePostRequest.builder()
+        .title("Updated Title")
+        .content("Updated Content")
+        .build();
+
+    mockMvc.perform(put("/api/posts/" + postId)
+            .header("Authorization", token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.postId").value(postId))
+        .andExpect(jsonPath("$.message").value("게시글이 성공적으로 수정되었습니다."));
+
+    mockMvc.perform(delete("/api/posts/" + postId)
+            .header("Authorization", token))
+        .andExpect(status().isNoContent());
+  }
+}

--- a/src/test/java/com/github/shCHO9801/climbing_record_app/community/posting/service/PostServiceTest.java
+++ b/src/test/java/com/github/shCHO9801/climbing_record_app/community/posting/service/PostServiceTest.java
@@ -1,0 +1,296 @@
+package com.github.shCHO9801.climbing_record_app.community.posting.service;
+
+import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.CLIMBING_GYM_NOT_FOUND;
+import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.POST_NOT_FOUND;
+import static com.github.shCHO9801.climbing_record_app.exception.ErrorCode.UNAUTHORIZED_ACTION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.shCHO9801.climbing_record_app.climbinggym.entity.ClimbingGym;
+import com.github.shCHO9801.climbing_record_app.climbinggym.repository.ClimbingGymRepository;
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostRequest;
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.PostMediaRequest;
+import com.github.shCHO9801.climbing_record_app.community.posting.dto.UpdatePostRequest;
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.GetPostResponse;
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.MediaType;
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.Post;
+import com.github.shCHO9801.climbing_record_app.community.posting.entity.PostMedia;
+import com.github.shCHO9801.climbing_record_app.community.posting.repository.PostMediaRepository;
+import com.github.shCHO9801.climbing_record_app.community.posting.repository.PostRepository;
+import com.github.shCHO9801.climbing_record_app.exception.CustomException;
+import com.github.shCHO9801.climbing_record_app.user.entity.Role;
+import com.github.shCHO9801.climbing_record_app.user.entity.User;
+import com.github.shCHO9801.climbing_record_app.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DisplayName("게시글 유닛 테스트")
+class PostServiceTest {
+
+  @InjectMocks
+  private PostService postService;
+
+  @Mock
+  private PostRepository postRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private ClimbingGymRepository climbingGymRepository;
+
+  @Mock
+  private PostMediaRepository postMediaRepository;
+
+  private User user;
+  private Post post;
+  private ClimbingGym gym;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    user = User.builder()
+        .userNum(1L)
+        .id("user")
+        .password("password")
+        .email("test@email.com")
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    gym = ClimbingGym.builder()
+        .id(100L)
+        .price(20000)
+        .name("testGym")
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    post = Post.builder()
+        .id(1L)
+        .title("title")
+        .content("content")
+        .climbingGym(gym)
+        .user(user)
+        .createdAt(LocalDateTime.now())
+        .build();
+  }
+
+  @Test
+  @DisplayName("게시글 생성 성공")
+  void createPostSuccess() {
+    //given
+    CreatePostRequest request = CreatePostRequest.builder()
+        .title("title")
+        .content("content")
+        .climbingGymId(100L)
+        .media(Arrays.asList(
+            PostMediaRequest.builder()
+                .mediaUrl("http://example.com/image.jpg")
+                .mediaType(MediaType.IMAGE)
+                .build()
+        ))
+        .build();
+
+    when(userRepository.findByUsername(user.getId()))
+        .thenReturn(Optional.of(user));
+    when(climbingGymRepository.findById(gym.getId()))
+        .thenReturn(Optional.of(gym));
+    when(postRepository.save(any(Post.class))).thenReturn(post);
+
+    //when
+    Post createdPost = postService.createPost(user.getId(), request);
+
+    //then
+    assertNotNull(createdPost);
+    assertEquals(post.getTitle(), createdPost.getTitle());
+    assertEquals(post.getContent(), createdPost.getContent());
+    assertEquals(post.getClimbingGym(), createdPost.getClimbingGym());
+    assertEquals(post.getCreatedAt(), createdPost.getCreatedAt());
+    assertEquals(post.getUser().getId(), createdPost.getUser().getId());
+    verify(postMediaRepository, times(1)).save(any(PostMedia.class));
+  }
+
+  @Test
+  @DisplayName("게시글 생성 실패 - 유저 미존재")
+  void createPostFailUserNotFound() {
+    //given
+    CreatePostRequest request = CreatePostRequest.builder()
+        .title("title")
+        .content("content")
+        .climbingGymId(100L)
+        .build();
+
+    when(userRepository.findByUsername("nonExistsUserName"))
+        .thenReturn(Optional.empty());
+
+    //when&then
+    assertThrows(CustomException.class,
+        () -> postService.createPost("nonExistsUserName", request));
+    verify(postMediaRepository, never()).save(any(PostMedia.class));
+  }
+
+  @Test
+  @DisplayName("게시글 생성 실패 - 클라이밍장 미존재")
+  void createPostFailClimbingGymNotFound() {
+    //given
+    CreatePostRequest request = CreatePostRequest.builder()
+        .title("title")
+        .content("content")
+        .climbingGymId(5L)
+        .build();
+
+    when(userRepository.findByUsername(user.getId()))
+        .thenReturn(Optional.of(user));
+
+    when(climbingGymRepository.findById(5L))
+        .thenReturn(Optional.empty());
+
+    //when&then
+    CustomException exception = assertThrows(CustomException.class,
+        () -> postService.createPost(user.getId(), request));
+    assertEquals(exception.getErrorCode(), CLIMBING_GYM_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("게시글 조회 성공")
+  void getPostSuccess() {
+    //given
+    when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+
+    //when
+    GetPostResponse foundPost = postService.getPost(1L);
+
+    //then
+    assertNotNull(post);
+    assertEquals(foundPost.getTitle(), post.getTitle());
+    assertEquals(foundPost.getContent(), post.getContent());
+    assertEquals(foundPost.getGymId(), post.getClimbingGym().getId());
+    assertEquals(foundPost.getUserId(), post.getUser().getId());
+  }
+
+  @Test
+  @DisplayName("게시글 조회 실패 - 게시글 미존재")
+  void getPostFailPostNotFound() {
+    //given
+    when(postRepository.findById(999L)).thenReturn(Optional.empty());
+
+    //when&then
+    CustomException exception = assertThrows(CustomException.class,
+        () -> postService.getPost(999L));
+
+    assertEquals(exception.getErrorCode(), POST_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("게시글 목록 조회 성공")
+  void getAllPostsSuccess() {
+    //given
+    Pageable pageable = PageRequest.of(0, 10);
+    List<Post> posts = Arrays.asList(post, post);
+    when(postRepository.findAll(pageable)).thenReturn(new PageImpl<>(posts));
+
+    //when
+    var pageResponse = postService.getAllPosts(pageable);
+
+    //then
+    assertNotNull(pageResponse);
+    assertEquals(2, pageResponse.getTotalElements());
+    assertEquals(post, pageResponse.getContent().get(0));
+    assertEquals(post, pageResponse.getContent().get(1));
+  }
+
+  @Test
+  @DisplayName("게시글 수정 성공")
+  void updatePostSuccess() {
+    //given
+    UpdatePostRequest request = UpdatePostRequest.builder()
+        .title("Update")
+        .content("UpdateContent")
+        .build();
+
+    when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+
+    Post updatePost = Post.builder()
+        .id(post.getId())
+        .title(request.getTitle())
+        .content(request.getContent())
+        .user(post.getUser())
+        .climbingGym(post.getClimbingGym())
+        .createdAt(post.getCreatedAt())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    when(postRepository.save(any(Post.class))).thenReturn(updatePost);
+
+    //when
+    Post result = postService.updatePost(user.getId(), post.getId(), request);
+
+    //then
+    assertNotNull(result);
+    assertEquals(updatePost.getTitle(), result.getTitle());
+    assertEquals(updatePost.getContent(), result.getContent());
+    assertEquals(updatePost.getUser().getId(), result.getUser().getId());
+  }
+
+  @Test
+  @DisplayName("게시글 수정 실패 - 권한 없음")
+  void updatePostFailUnauthorized() {
+    //given
+    UpdatePostRequest request = UpdatePostRequest.builder()
+        .title("Update")
+        .content("UpdateContent")
+        .build();
+
+    when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+
+    //when&then
+    CustomException exception = assertThrows(CustomException.class,
+        () -> postService.updatePost("anotherUser", post.getId(), request));
+
+    assertEquals(exception.getErrorCode(), UNAUTHORIZED_ACTION);
+  }
+
+  @Test
+  @DisplayName("게시글 삭제 성공")
+  void deletePostSuccess() {
+    //given
+    when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+
+    //when
+    postService.deletePost(user.getId(), post.getId());
+
+    //then
+    verify(postRepository, times(1)).delete(any(Post.class));
+  }
+
+  @Test
+  @DisplayName("게시글 삭제 실패 - 권한 없음")
+  void deletePostFailUnauthorized() {
+    //given
+    when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+
+    //when&then
+    CustomException exception = assertThrows(CustomException.class,
+        () -> postService.deletePost("anotherUser", post.getId()));
+
+    assertEquals(exception.getErrorCode(), UNAUTHORIZED_ACTION);
+    verify(postRepository, never()).delete(any(Post.class));
+  }
+}

--- a/src/test/java/com/github/shCHO9801/climbing_record_app/community/posting/service/PostServiceTest.java
+++ b/src/test/java/com/github/shCHO9801/climbing_record_app/community/posting/service/PostServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import com.github.shCHO9801.climbing_record_app.climbinggym.entity.ClimbingGym;
 import com.github.shCHO9801.climbing_record_app.climbinggym.repository.ClimbingGymRepository;
+import com.github.shCHO9801.climbing_record_app.community.comment.repository.CommentRepository;
 import com.github.shCHO9801.climbing_record_app.community.posting.dto.CreatePostRequest;
 import com.github.shCHO9801.climbing_record_app.community.posting.dto.PostMediaRequest;
 import com.github.shCHO9801.climbing_record_app.community.posting.dto.UpdatePostRequest;
@@ -58,6 +59,9 @@ class PostServiceTest {
 
   @Mock
   private PostMediaRepository postMediaRepository;
+
+  @Mock
+  private CommentRepository commentRepository;
 
   private User user;
   private Post post;

--- a/src/test/java/com/github/shCHO9801/climbing_record_app/user/controller/ProfileControllerTest.java
+++ b/src/test/java/com/github/shCHO9801/climbing_record_app/user/controller/ProfileControllerTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc
 @Transactional
 @ActiveProfiles("testH2")
+@DisplayName("유저 프로필 인테그레이션 테스트")
 class ProfileControllerTest {
 
   @Autowired


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 클라이밍 관련 기능 외에 커뮤니티(게시글, 미디어) 기능 미구현
- 게시글 관련 엔티티와 Repository 미구현으로, 게시글에 여러 첨부 미디어(사진/동영상)를 처리할 수 없는 상태
- 게시글 CRUD API 미구현 (생성, 수정, 조회, 삭제 기능 모두 누락)
- 게시글 조회 시 정렬 및 페이지네이션 기능 미지원
- 게시글 관련 데이터(첨부 미디어 URL)가 게시글 엔티티에 직접 저장되어 데이터 구조가 난잡함
- 관련 기능에 대한 유닛테스트 및 통합 테스트 미작성

**TO-BE**
- 게시글(Post) 및 미디어(PostMedia) 엔티티 구현
  - 게시글(Post) 엔티티는 제목, 내용, 작성자(User), 클라이밍장(ClimbingGym) 정보, 생성/수정 일시 등을 포함
  - 미디어(PostMedia) 엔티티는 미디어 URL, 미디어 타입(MediaType: IMAGE, VIDEO)을 가지며, 게시글과 ManyToOne 관계를 가짐
- Repository 구현
  - PostRepository와 PostMediaRepository를 구현하여 각각 게시글과 첨부 미디어의 CRUD를 지원
- 서비스 레이어 구현
  - PostService를 구현하여 게시글 생성 시, 로그인한 사용자의 아이디를 기준으로 게시글과 함께 첨부 미디어(PostMedia)를 별도의 테이블에 저장하도록 구성
  - 게시글 조회 시에는 페이지네이션 및 최신 순(예: createdAt 내림차순) 기능을 적용하여 반환
  - 게시글 수정 및 삭제 시에는 작성자와 요청자 일치 여부를 검사하여 권한 없는 수정/삭제를 방지
  - AWS S3 연동은 추후 계획이며, 현재는 미디어 URL을 전달받아 저장하는 형태로 구현
- 컨트롤러 구현
  - PostController에서는 JWT 토큰을 이용하여 사용자 인증 후 게시글 CRUD API를 제공
  - JWT 토큰은 "Bearer {token}" 형식으로 전달되며, 컨트롤러 내에서 추출 및 사용자 ID 확인 후 서비스 호출
  - 생성, 조회(페이지네이션 포함), 수정, 삭제 API 구현
- DTO 구성
  - CreatePostRequest: 제목, 내용, 클라이밍장 ID, 최대 10개까지의 미디어(PostMediaRequest) 목록을 입력받도록 정의 (미디어 갯수는@Size(max=10) 등으로 검증)
  - CreatePostResponse: 게시글 생성 결과 (게시글 ID 및 성공 메시지 등)
  - UpdatePostRequest: 제목과 내용 수정에 필요한 데이터

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- 유닛 테스트
  - Service 단에서 PostService의 createPost, getPost, updatePost, deletePost 등의 메서드에 대해
정상/비정상 시나리오(예: 사용자 미존재, 클라이밍장 미존재, 권한 없는 수정/삭제)를 검증하는 테스트 코드 작성
  - Repository와의 상호작용(예: 첨부 미디어 저장)이 올바르게 호출되는지 검증
- 통합 테스트
  - PostController를 대상으로 실제 API 호출을 통해 게시글 생성 및 조회, 수정, 삭제가 올바르게 동작하는지 확인
  - JWT 토큰을 통한 인증(Authorization 헤더에서 Bearer 토큰 처리) 및 페이지네이션 적용된 게시글 조회 기능 테스트
- [ ] API 테스트 